### PR TITLE
Display signup schedule in a responsive calendar form

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -59,3 +59,20 @@ TABLE.pta-sus-sheets .column-view_link {
 .pta-sus-em {
     font-style: italic;
 }
+
+/* Styles for an adaptive calendar */
+
+.vsus_date {font-weight: bold;}
+.vsus_time {margin: 0 1 0 1;
+	background:#eee;}
+
+.vsus_container ul{ list-style: none; padding: 0; margin: 0; clear: both; width: 100%; } .vsus_container li{ display: block; float: left; width: 14.2857142857%; padding: 5px; box-sizing: border-box; border: 1px solid #ccc; margin-right: -1px; margin-bottom: -1px; }
+
+@media only screen and (min-width : 768px) { .day_cell { display: none; } }
+
+@media only screen and (max-width : 768px) { 
+.vsus_container .weekdays { display: none; } 
+.vsus_container li { height: auto!important; border: 1px solid #ededed; width: 100%; padding: 10px; margin-bottom: -1px; } 
+.vsus_container li .day, .vsus_container li .month { display: inline; } 
+.vsus_container li.outofrange { display: none; } 
+}

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -18,10 +18,10 @@ TABLE.pta-sus-sheets TH {
 TABLE.pta-sus-sheets TD,
 TABLE.pta-sus-tasks TH,
 TABLE.pta-sus-sheets TH {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 3px solid #ccc; /*changed from 1px to 3px*/
     }
 TR.pta-sus-tasks-bb TD {
-    border-bottom: 1px solid #ccc;
+    border-bottom: 3px solid #ccc; /*changed from 1px to 3px*/
     }
 TABLE.pta-sus-sheets TR.filled {
     background: #eee;
@@ -60,19 +60,19 @@ TABLE.pta-sus-sheets .column-view_link {
     font-style: italic;
 }
 
-/* Styles for an adaptive calendar */
+/* ADDED BY JM AND AP */
 
 .vsus_date {font-weight: bold;}
 .vsus_time {margin: 0 1 0 1;
-	background:#eee;}
+	background:#E8E8E2;}
 
-.vsus_container ul{ list-style: none; padding: 0; margin: 0; clear: both; width: 100%; } .vsus_container li{ display: block; float: left; width: 14.2857142857%; padding: 5px; box-sizing: border-box; border: 1px solid #ccc; margin-right: -1px; margin-bottom: -1px; }
+.vsus_container ul{ list-style: none; padding: 0; margin: 0; clear: both; width: 100%;} .vsus_container li{ display: block; float: left; width: 14.2857142857%; padding: 5px; box-sizing: border-box; border-top: 1px solid #cfcec3; border-left: 1px solid #cfcec3; border-right: 1px solid #cfcec3; margin-right: -1px; margin-bottom: -1px; }
 
 @media only screen and (min-width : 768px) { .day_cell { display: none; } }
 
 @media only screen and (max-width : 768px) { 
 .vsus_container .weekdays { display: none; } 
-.vsus_container li { height: auto!important; border: 1px solid #ededed; width: 100%; padding: 10px; margin-bottom: -1px; } 
+.vsus_container li { height: auto!important; width: 100%; padding: 10px; margin-bottom: -1px; } 
 .vsus_container li .day, .vsus_container li .month { display: inline; } 
 .vsus_container li.outofrange { display: none; } 
 }


### PR DESCRIPTION
This changes class-pta_sus_public.php so that its output uses list (ul/li) markup instead of table markup, but is styled as a responsive calendar: if the page is wide enough, it looks like a tabular calendar, but on narrower screens (like a phone), it will degrade gracefully to a list.
